### PR TITLE
Solución de errores del apartado 2 y 9 de la documentación

### DIFF
--- a/docs/02_architecture_constraints.adoc
+++ b/docs/02_architecture_constraints.adoc
@@ -1,8 +1,8 @@
 [[section-architecture-constraints]]
 == Architectural constraints
 
-=== Technical restrictions::
-****
+=== Technical restrictions
+
 |===
 |Requirement|Explanation
 |React|Framework oriented to the Frontend of the application.
@@ -13,8 +13,8 @@
 |===
 ****
 
-=== Organizational restrictions::
-****
+=== Organizational restrictions
+
 |===
 |Requirement|Explanation
 |GitHub|Git version control system with additional tools.
@@ -24,8 +24,8 @@
 |===
 ****
 
-=== Convections::
-****
+=== Convections
+
 |===
 |Requirement|Explanation
 |Arc42|To develop the documentation we will follow the Arc42 model.

--- a/docs/02_architecture_constraints.adoc
+++ b/docs/02_architecture_constraints.adoc
@@ -1,37 +1,35 @@
 [[section-architecture-constraints]]
 == Architectural constraints
 
-=== Contents
-This section shows the different restrictions on the DeDe project classified into technical, organizational and convective restrictions.
-
-Technical restrictions::
-[options="header",cols="1,2"]
+=== Technical restrictions::
+****
 |===
 |Requirement|Explanation
 |React|Framework oriented to the Frontend of the application.
 |Typescript|Programming language for business logic.
 |Solid|Solid Pods will be used to obtain customers' personal information.
-|MongoDb|NoSql database where the information about the store will be stored.
 |Hosting|The application must be continuously accessible.
 |Testing|Automatic and manual tests on the code.
 |===
+****
 
-Organizational restrictions::
-[options="header",cols="1,2"]
+=== Organizational restrictions::
+****
 |===
 |Requirement|Explanation
 |GitHub|Git version control system with additional tools.
 |Working group|The group is made up of 4 people.
 |Meetings|At least one team meeting per week will be held and recorded.
-|Deliveries|There must be continuous deliveries that add value to the application.
+|Delivery times|Approximately every 3 weeks there will be deliveries to know the status of the application and its documentation.
 |===
+****
 
-Convections::
-[options="header",cols="1,2"]
+=== Convections::
+****
 |===
 |Requirement|Explanation
-|Internationalization|Both the application and the documentation will be implemented in English in order to reach more people.
 |Arc42|To develop the documentation we will follow the Arc42 model.
 |SOLID|SOLID principles will be followed with respect to customer privacy.
 |Interface|The interface must be intuitive for non-technical people.
 |===
+****

--- a/docs/02_architecture_constraints.adoc
+++ b/docs/02_architecture_constraints.adoc
@@ -11,7 +11,6 @@
 |Hosting|The application must be continuously accessible.
 |Testing|Automatic and manual tests on the code.
 |===
-****
 
 === Organizational restrictions
 
@@ -22,7 +21,6 @@
 |Meetings|At least one team meeting per week will be held and recorded.
 |Delivery times|Approximately every 3 weeks there will be deliveries to know the status of the application and its documentation.
 |===
-****
 
 === Convections
 
@@ -32,4 +30,3 @@
 |SOLID|SOLID principles will be followed with respect to customer privacy.
 |Interface|The interface must be intuitive for non-technical people.
 |===
-****

--- a/docs/09_design_decisions.adoc
+++ b/docs/09_design_decisions.adoc
@@ -6,7 +6,7 @@ This section shows the different design decisions presented in a table sorted by
 
 |===
 |Decision|Pros|Cons
-|SOLID|Respect for the privacy of user data|Technology unknown to the group
+|Internationalization|By internationalizing the application, we can reach a larger number of people|Increased difficulty in documentation and implementation
 |NoSql|Versatile and well-integrated databases for this project|They do not have atomicity and do not allow transactions
 |GitHub|Allows version control with utility tools|Some functions are subject to a fee
 |===


### PR DESCRIPTION
Se arreglan los errores dichos en clase y se añade una división más clara a las divisiones de restricciones del apartado 2. También añado la internacionalización al apartado 9 y quito la restricción que tenía.